### PR TITLE
Upgrade to Rust Edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["MathxH Chen <brainfvck@foxmail.com>"]
 description = "A Simple Publicly Verifiable Secret Sharing Library"
-edition = "2021"
+edition = "2024"
 keywords = ["pvss-scheme", "secret-sharing", "threshold-crypto", "zero-knowledge-proof"]
 license = "MIT OR Apache-2.0"
 name = "mpvss-rs"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2018"
+edition = "2024"
 hard_tabs = false
 max_width = 80
 tab_spaces = 4

--- a/src/mpvss.rs
+++ b/src/mpvss.rs
@@ -220,7 +220,9 @@ impl MPVSS {
                 exponent = (numerator.to_bigint().unwrap() * inverseDenom)
                     % q1.to_bigint().unwrap();
             } else {
-                eprintln!("ERROR: Denominator of Lagrange coefficient fraction does not have an inverse. Share cannot be processed.");
+                eprintln!(
+                    "ERROR: Denominator of Lagrange coefficient fraction does not have an inverse. Share cannot be processed."
+                );
             }
         }
         let mut factor = share
@@ -234,7 +236,9 @@ impl MPVSS {
             if let Some(inversefactor) = inverseFactor {
                 factor = inversefactor;
             } else {
-                eprintln!("ERROR: Lagrange coefficient was negative and does not have an inverse. Share cannot be processed.")
+                eprintln!(
+                    "ERROR: Lagrange coefficient was negative and does not have an inverse. Share cannot be processed."
+                )
             }
         }
 

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -652,9 +652,9 @@ mod tests {
 
     use super::BTreeMap;
     use super::BigInt;
+    use super::MPVSS;
     use super::Participant;
     use super::Polynomial;
-    use super::MPVSS;
     use super::{DistributionSharesBox, ShareBox};
     use num_traits::{One, Zero};
 


### PR DESCRIPTION
- Update Cargo.toml edition from 2021 to 2024
- Update rustfmt.toml edition from 2018 to 2024 (fix inconsistency)
- All tests pass with new edition